### PR TITLE
fix error pdf export

### DIFF
--- a/buku/artivisi-template.tex
+++ b/buku/artivisi-template.tex
@@ -41,6 +41,7 @@ $endif$
 \lfoot{v$version$}
 \cfoot{}
 \rfoot{\thepage}
+\def\tightlist{}
 
 $if(geometry)$
 \usepackage[$for(geometry)$$geometry$$sep$,$endfor$]{geometry}


### PR DESCRIPTION
Selamat malam, template latex yang anda gunakan outdated sehingga waktu saya export pdf ada masalah dimana keyword tightlist juga ada di pandoc.
workaround yang saya gunakan adalah dengan menambahkan macro untuk tightlist pada template yang anda gunakan.

referensi : http://tex.stackexchange.com/questions/257418/error-tightlist-converting-md-file-into-pdf-using-pandoc